### PR TITLE
Add support for custom fields to v3 format

### DIFF
--- a/zerologv3_test.go
+++ b/zerologv3_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestV3LogFormatMessage(t *testing.T) {
+func TestV3LogEmptyMessage(t *testing.T) {
 	// Arrange
 	var outbuf bytes.Buffer
 	v3logger := zerolog.New(V3FormatWriter{Out: &outbuf})
@@ -19,7 +19,7 @@ func TestV3LogFormatMessage(t *testing.T) {
 
 	// Assert
 	actualMessage := outbuf.String()
-	expectedMessage := `{"log_format":"v3","metadata":{"log_level":"INFO","message_type":"","timestamp":""},"payload":{"message":""},"source":{"app_name":""}}`
+	expectedMessage := `{"log_format":"v3","metadata":{"log_level":"INFO","message_type":"","timestamp":""},"payload":{},"source":{"app_name":""}}`
 	expectedMessage += "\n"
 	assert.Equal(t, expectedMessage, actualMessage)
 }
@@ -28,7 +28,7 @@ func returnFixedTimestamp() time.Time {
 	return time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC)
 }
 
-func TestV3LogFormatAllFields(t *testing.T) {
+func TestV3LogAllV3Fields(t *testing.T) {
 	// Arrange
 	var outbuf bytes.Buffer
 	v3logger := zerolog.New(V3FormatWriter{Out: &outbuf}).
@@ -45,6 +45,25 @@ func TestV3LogFormatAllFields(t *testing.T) {
 	// Assert
 	actualMessage := outbuf.String()
 	expectedMessage := `{"log_format":"v3","metadata":{"log_level":"DEBUG","message_type":"MesssageTypeTest","timestamp":"2009-11-17T20:34:58Z"},"payload":{"message":"Test"},"source":{"app_name":"AppNameTest"}}`
+	expectedMessage += "\n"
+	assert.Equal(t, expectedMessage, actualMessage)
+}
+
+func TestV3LogCustomField(t *testing.T) {
+	// Arrange
+	var outbuf bytes.Buffer
+	v3logger := zerolog.New(V3FormatWriter{Out: &outbuf}).
+		With().
+		Str("custom_field", "CustomField1").
+		Logger()
+	zerolog.TimestampFunc = returnFixedTimestamp
+
+	// Act
+	v3logger.Debug().Msg("")
+
+	// Assert
+	actualMessage := outbuf.String()
+	expectedMessage := `{"log_format":"v3","metadata":{"log_level":"DEBUG","message_type":"","timestamp":""},"payload":{"custom_field":"CustomField1"},"source":{"app_name":""}}`
 	expectedMessage += "\n"
 	assert.Equal(t, expectedMessage, actualMessage)
 }


### PR DESCRIPTION
Add support for custom fields in V3. All custom fields are represented in payload
