### PR TITLE
Add proxy support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   - GO111MODULE=on
 
 before_script:
-  - go mod vendor
+  - go mod download
   - go get -u github.com/mattn/goveralls
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,43 @@
 # Build stage
 FROM golang:1.11 as builder
 
-LABEL maintainer="Travix"
+# Create the user and group files that will be used in the running container to
+# run the process as an unprivileged user.
+RUN mkdir /user && \
+    echo 'nobody:x:65534:65534:nobody:/:' > /user/passwd && \
+    echo 'nobody:x:65534:' > /user/group
 
-COPY ./ /go/src/gozzmock
-ENV GO111MODULE=on
-WORKDIR /go/src/gozzmock
-RUN go mod vendor
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -mod vendor -o gozzmock_bin .
+# Import the code from the context.
+COPY ./ /src
+
+# Set the working directory outside $GOPATH to enable the support for modules.
+WORKDIR /src
+
+# Download modules to local cache
+RUN go mod download
+
+# Set the environment variables for the go command:
+# * CGO_ENABLED=0 to build a statically-linked executable
+# Build the executable to `/gozzmock_bin`. Mark the build as statically linked.
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o /gozzmock_bin .
 
 # Run stage
-FROM scratch
+FROM scratch AS final
 
 LABEL maintainer="Travix"
 
+# Import the user and group files from the first stage.
+COPY --from=builder /user/group /user/passwd /etc/
+
+# Import the Certificate-Authority certificates for enabling HTTPS.
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /go/src/gozzmock/gozzmock_bin .
+
+# Import the compiled executable from the second stage.
+COPY --from=builder /gozzmock_bin /gozzmock_bin
 
 EXPOSE 8080
+
+# Perform any further action as an unprivileged user.
+USER nobody:nobody
 
 ENTRYPOINT ["./gozzmock_bin"]

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ default: lint vet test
 
 .PHONY: test
 test:
-	go mod vendor
+	go mod download
 	go test -coverprofile=$(COVERFILENAME).out ./...
 	go tool cover -html=$(COVERFILENAME).out -o $(COVERFILENAME)_all.html
 	rm $(COVERFILENAME).out
@@ -31,10 +31,8 @@ update:
 
 .PHONY: build-linux
 build-linux:
-	go mod download
 	GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -a -o $(BINARY_NAME) .
 
 .PHONY: build-windows
 build-windows:
-	go mod download
 	GO111MODULE=on CGO_ENABLED=0 GOOS=windows go build -a -installsuffix cgo -mod vendor -o $(BINARY_NAME).exe .

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 COVERFILENAME:=cover
-BINARY_NAME:=gozzmock
+BINARY_NAME:=gozzmock_bin
 
 default: lint vet test
 
@@ -31,8 +31,10 @@ update:
 
 .PHONY: build-linux
 build-linux:
-	GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -mod vendor -o $(BINARY_NAME) .
+	go mod download
+	GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -a -o $(BINARY_NAME) .
 
 .PHONY: build-windows
 build-windows:
+	go mod download
 	GO111MODULE=on CGO_ENABLED=0 GOOS=windows go build -a -installsuffix cgo -mod vendor -o $(BINARY_NAME).exe .

--- a/gzHttpClient.go
+++ b/gzHttpClient.go
@@ -5,18 +5,18 @@ import (
 )
 
 type httpClient interface {
-	do(req *http.Request) (*http.Response, error)
+	roundTrip(req *http.Request) (*http.Response, error)
 }
 
 type gzHTTPClient struct {
-	httpClient *http.Client
+	roundTripper http.RoundTripper
+}
+
+func (gzClient *gzHTTPClient) roundTrip(req *http.Request) (*http.Response, error) {
+	return gzClient.roundTripper.RoundTrip(req)
 }
 
 func newGzHTTPClient() *gzHTTPClient {
 	return &gzHTTPClient{
-		httpClient: &http.Client{}}
-}
-
-func (gzClient *gzHTTPClient) do(req *http.Request) (*http.Response, error) {
-	return gzClient.httpClient.Do(req)
+		roundTripper: http.DefaultTransport}
 }

--- a/gzserver.go
+++ b/gzserver.go
@@ -324,15 +324,18 @@ func (server *gzServer) doHTTPRequest(w http.ResponseWriter, httpReq *http.Reque
 		dumpRequest(httpReq)
 	}
 
-	resp, err := server.httpClient.do(httpReq)
+	resp, err := server.httpClient.roundTrip(httpReq)
 	if err != nil {
 		fLog.Panic().Err(err)
 		reportError(w)
 		return
 	}
-	if resp != nil {
-		defer resp.Body.Close()
+
+	if resp == nil {
+		fLog.Panic().Msg("response is nil")
+		return
 	}
+	defer resp.Body.Close()
 
 	if server.logLevel == zerolog.DebugLevel {
 		dumpResponse(resp)

--- a/gzserver_test.go
+++ b/gzserver_test.go
@@ -165,7 +165,7 @@ func httpNewRequestMust(method, url string, body io.Reader) *http.Request {
 type gzMockedHTTPClient struct {
 }
 
-func (gzClient *gzMockedHTTPClient) do(req *http.Request) (*http.Response, error) {
+func (gzClient *gzMockedHTTPClient) roundTrip(req *http.Request) (*http.Response, error) {
 	var sb strings.Builder
 	sb.WriteString(req.URL.String())
 	sb.WriteString(" Host:")
@@ -176,7 +176,7 @@ func (gzClient *gzMockedHTTPClient) do(req *http.Request) (*http.Response, error
 		sb.WriteString(":")
 		sb.WriteString(strings.Join(v, ","))
 	}
-	
+
 	body := ioutil.NopCloser(strings.NewReader(sb.String()))
 	response := &http.Response{StatusCode: 200, Body: body}
 	return response, nil
@@ -358,7 +358,7 @@ func TestHandlerRoot_ForwardValidatrHeaders(t *testing.T) {
 type gzMockedGzipHTTPClient struct {
 }
 
-func (gzClient *gzMockedGzipHTTPClient) do(req *http.Request) (*http.Response, error) {
+func (gzClient *gzMockedGzipHTTPClient) roundTrip(req *http.Request) (*http.Response, error) {
 	resp := http.Response{
 		Header: make(http.Header)}
 


### PR DESCRIPTION
By default, http client "Do" method doesn't support http proxy. In order to support it out of the box, I use http DefaultTransport.

Additionally, I update Dockerfile: create a separate user to run application without root access and remove installsuffix , because it is not needed