### PR TITLE
Change the header lookup to be case insensitive

### DIFF
--- a/expectations/filter.go
+++ b/expectations/filter.go
@@ -221,6 +221,17 @@ func stringsMatch(req string, exp string) bool {
 	return r.MatchString(req)
 }
 
+// findInMapCaseInsensitive looks up the specified key in the map using case-insensitive lookup
+func findInMapCaseInsensitive(m map[string]string, k string) (string, bool) {
+	for name, value := range m {
+		if strings.EqualFold(name, k) {
+			return value, true
+		}
+	}
+
+	return "", false
+}
+
 // headersMatch validates whether the input string has filter string as substring or as a regex
 func headersMatch(req Headers, exp Headers) bool {
 	if len(exp) == 0 {
@@ -228,7 +239,7 @@ func headersMatch(req Headers, exp Headers) bool {
 	}
 
 	for expName, expValue := range exp {
-		reqValue, ok := req[expName]
+		reqValue, ok := findInMapCaseInsensitive(req, expName)
 		if ok && stringsMatch(reqValue, expValue) {
 			continue
 		}

--- a/expectations/filter_test.go
+++ b/expectations/filter_test.go
@@ -128,6 +128,12 @@ func TestExpectationsMatch_HeadersAreEq_True(t *testing.T) {
 		&ExpectationRequest{Headers: Headers{"h1": "hv1"}}))
 }
 
+func TestExpectationsMatch_HeadersAreEqDifferentCase_True(t *testing.T) {
+	assert.True(t, expectationsMatch(
+		&ExpectationRequest{Headers: Headers{"h1": "hv1"}},
+		&ExpectationRequest{Headers: Headers{"H1": "hv1"}}))
+}
+
 func TestExpectationsMatch_HeaderNotEq_False(t *testing.T) {
 	result := expectationsMatch(
 		&ExpectationRequest{Headers: Headers{"h1": "hv1"}},


### PR DESCRIPTION
When an expectation is configured, the header name goes through this `CanonicalMIMEHeaderKey` function (https://golang.org/src/net/textproto/reader.go?s=16088:16132#L586), which changes the casing of the header, for example from `SessionID` to `Sessionid`.

But then we do the actual lookup in a case sensitive way.  
This means that if we setup the expectation as `SessionID`, and then send the actual request with the header `SessionID`, it won't work, because in the expectation collection the value will be `Sessionid`.

This PR changes the lookup to be case-insensitive, which is the correct behavior anyway, because in the HTTP standard the header names are insensitive (https://tools.ietf.org/html/rfc2616#section-4.2).